### PR TITLE
Support non-alphanumeric characters in password

### DIFF
--- a/PyFileMaker/FMServer.py
+++ b/PyFileMaker/FMServer.py
@@ -38,7 +38,7 @@ class FMServer:
 
 		self._url = url
 
-		m = re.match(r'^((?P<protocol>http)://)?((?P<login>\w+)(:(?P<password>\w+))?@)?(?P<host>[\d\w\-.]+)(:(?P<port>\d+))?/?(?P<address>/.+)?$', self._url)
+		m = re.match(r'^((?P<protocol>http)://)?((?P<login>\w+)(:(?P<password>[^@]+))?@)?(?P<host>[\d\w\-.]+)(:(?P<port>\d+))?/?(?P<address>/.+)?$', self._url)
 
 		if not m:
 			raise FMError, "Address of FileMaker Server is not correctly formatted"


### PR DESCRIPTION
The current URL parsing assumes that both username and passwords passed in the URL match Python's `\w` regular expression character class, which [limits](https://docs.python.org/2/library/re.html#regular-expression-syntax) acceptable characters to `[a-zA-Z0-9_]`.

The FileMaker [docs](http://help.filemaker.com/app/answers/detail/a_id/2908/~/tips-for-creating-secure-passwords) on choosing secure passwords suggest that you

> use only a combination of the characters A through Z, with at least one numeral. Do not include spaces, special characters, or high ASCII characters in your password, as these may be interpreted incorrectly over the Web

Even so, HTTP Basic Authentication does support additional characters as does for example Python's [urlparse](https://docs.python.org/2/library/urlparse.html). This PR modifies the parser so that passwords can contain these extra characters.

Is there any reason why this library couldn't also use something standard like `urlparse` to parse the initializing URL, instead of doing it manually?