### PR TITLE
Added default port 443 for https protocol.

### DIFF
--- a/PyFileMaker/FMServer.py
+++ b/PyFileMaker/FMServer.py
@@ -44,7 +44,7 @@ class FMServer:
 		self._login    = parsed.username or 'pyfilemaker'
 		self._password = parsed.password or ''
 		self._host     = parsed.hostname or 'localhost'
-		self._port     = parsed.port     or 80
+		self._port     = parsed.port     or 443 if self._protocol == 'https' else 80
 		self._address  = parsed.path     or '/fmi/xml/fmresultset.xml'
 
 		self._file_address = 'fmi/xml/cnt/data.%(extension)s'


### PR DESCRIPTION
Other protocols (ie. http) still default to port 80. This was tested with Windows 32 bit Python 2.7.11 