### PR TITLE
 Added Empty String Checking

### DIFF
--- a/PyFileMaker/UnicodeNormalizer.py
+++ b/PyFileMaker/UnicodeNormalizer.py
@@ -61,6 +61,9 @@ def normalizeUnicode(text, encoding='humanascii'):
     letters. Output is ASCII encoded string (or char) with only ASCII letters,
     digits, punctuation and whitespace characters. Case is preserved.
     """
+    if text == "":
+	return ""
+
     unicodeinput = True
     if not isinstance(text, unicode):
         text = unicode(text, 'utf-8')
@@ -135,3 +138,4 @@ if __name__ == '__main__':
     print s
     s = normalizeUnicode(s, 'identifier')
     print s, type(s)
+


### PR DESCRIPTION
`res.strip('_')[0]` in Line 122 may throw an error on empty text passed into the function, therefore the check initially. 