### PR TITLE
Errant slash in url removed

### DIFF
--- a/PyFileMaker/FMServer.py
+++ b/PyFileMaker/FMServer.py
@@ -641,7 +641,7 @@ class FMServer:
 
 	def _buildUrl(self):
 		"""Builds url for normal FM requests."""
-		return '%(protocol)s://%(host)s:%(port)s/%(address)s'%{
+		return '%(protocol)s://%(host)s:%(port)s%(address)s'%{
 			'protocol': self._protocol,
 			'host': self._host,
 			'port': self._port,


### PR DESCRIPTION
Slash after port was being duplicated. https://github.com/aeguana/PyFileMaker/issues/9