### PR TITLE
Allow field names with double underscore

### DIFF
--- a/PyFileMaker/FMServer.py
+++ b/PyFileMaker/FMServer.py
@@ -179,7 +179,7 @@ class FMServer:
 			return self._setComparasionOperator(name[:-3], value)
 		if name.find('__') != -1:
 			import re
-			name = name.replace('__','::')
+			# name = name.replace('__','::')
 		elif name.find('.') != -1:
 			name = name.replace('.','::')
 


### PR DESCRIPTION
In the FileMaker documentation, examples of principal keys are given with the string: ```'__kp'```.
In the FileMaker 16 Server version this fields work well in the XML url petition.
This line must be commented to this fields to be admited by FMServer class.
