### PR TITLE
Fix date decoding in month/day/year format

### DIFF
--- a/PyFileMaker/FMData.py
+++ b/PyFileMaker/FMData.py
@@ -55,7 +55,7 @@ def makeFMData( from_dict, locked = False):
 				value = init_dict[key]
 				date, mo, da, ye, time, ho, mi, se = [None] * 8
 				if type(value) in [str, unicode]:
-					date, da, mo, ye, time, ho, mi, se = reDateTime.match( value ).groups()
+					date, mo, da, ye, time, ho, mi, se = reDateTime.match( value ).groups()
 					if mo and int(mo) > 12:
 						mo, da = da, mo
 


### PR DESCRIPTION
In FileMaker 16 Server version, dates are return in the ```month/day/year``` format, even when the idiom specifications are different from it.
The order of the groups must be changed for dates to work properly in this version.

